### PR TITLE
Add page navigation, metadata support, static site generation, and themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ erl_crash.dump
 manto-*.tar
 /priv/static/assets/
 /priv/static/cache_manifest.json
+/priv/static_site/
 npm-debug.log
 node_modules/
 /assets/node_modules/

--- a/README.md
+++ b/README.md
@@ -52,13 +52,15 @@ manto/
 
 [x] Local content folder
 
-[ ] Page navigation & wiki‑style links
+[x] Page navigation & wiki‑style links
 
-[ ] Metadata (frontmatter)
+[x] Metadata (frontmatter)
 
-[ ] Static site generator mode
+[x] Static site generator mode
 
-[ ] Theming and publishing
+[x] Theming 
+
+[] Publishing
 
 
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,6 +2,7 @@
    https://tailwindcss.com/docs/configuration */
 
 @import "tailwindcss" source(none);
+@plugin "@tailwindcss/typography"; /* fix for the preview to render markdown correctly, alucarddz */
 @source "../css";
 @source "../js";
 @source "../../lib/manto_web";

--- a/lib/manto/content/parser.ex
+++ b/lib/manto/content/parser.ex
@@ -5,15 +5,75 @@ defmodule Manto.Content.Parser do
 
   alias MDEx
 
+  @mdex_opts [extension: [front_matter_delimiter: "---", table: true]]
+  @wiki_link_regex ~r/\[\[([^\]]+)\]\]/
+
   @doc """
   Render Markdown into safe HTML string.
+
+  Wiki-style `[[Page Name]]` links are rewritten to `\#{link_prefix}Slug\#{link_suffix}`
+  (defaults to editor links, e.g. `/editor/Slug`; the static build uses `Slug.html` instead).
+  Front matter (if present) is stripped from the output.
+
   Always returns a binary, never a tuple.
   """
-  def render_html(markdown) when is_binary(markdown) do
-    case MDEx.to_html(markdown) do
+  @spec render_html(String.t(), keyword()) :: String.t()
+  def render_html(markdown, opts \\ []) when is_binary(markdown) do
+    markdown
+    |> rewrite_wiki_links(opts)
+    |> MDEx.to_html(@mdex_opts)
+    |> case do
       {:ok, html} -> html
-      html when is_binary(html) -> html
       _ -> ""
+    end
+  end
+
+  @doc """
+  Extract front matter as a string-keyed map, e.g. `---\\ntitle: Hi\\n---` -> %{"title" => "Hi"}.
+
+  Returns an empty map when there's no front matter.
+  """
+  @spec metadata(String.t()) :: map()
+  def metadata(markdown) when is_binary(markdown) do
+    with {:ok, doc} <- MDEx.parse_document(markdown, @mdex_opts),
+         %MDEx.FrontMatter{literal: literal} <-
+           Enum.find(doc.nodes, &match?(%MDEx.FrontMatter{}, &1)) do
+      parse_front_matter(literal)
+    else
+      _ -> %{}
+    end
+  end
+
+  defp rewrite_wiki_links(markdown, opts) do
+    prefix = Keyword.get(opts, :link_prefix, "/editor/")
+    suffix = Keyword.get(opts, :link_suffix, "")
+
+    Regex.replace(@wiki_link_regex, markdown, fn _, name ->
+      slug = String.replace(String.trim(name), " ", "-")
+      "[#{name}](#{prefix}#{slug}#{suffix})"
+    end)
+  end
+
+  defp parse_front_matter(literal) do
+    literal
+    |> String.split("\n")
+    |> Enum.reduce(%{}, &add_front_matter_line/2)
+  end
+
+  defp add_front_matter_line(line, acc) do
+    case parse_front_matter_line(line) do
+      {key, value} -> Map.put(acc, key, value)
+      :skip -> acc
+    end
+  end
+
+  defp parse_front_matter_line(line) do
+    with [key, value] <- String.split(line, ":", parts: 2),
+         key = String.trim(key),
+         true <- key != "" do
+      {key, String.trim(value)}
+    else
+      _ -> :skip
     end
   end
 end

--- a/lib/manto_web/live/editor_live.ex
+++ b/lib/manto_web/live/editor_live.ex
@@ -4,20 +4,58 @@ defmodule MantoWeb.EditorLive do
   alias Manto.Content.Parser
 
   def mount(_params, _session, socket) do
-    page = "welcome"
-    body = Content.get_page(page) || "# New Page"
-    html = Parser.render_html(body)
+    {:ok, assign(socket, pages: Content.list_pages())}
+  end
 
-    {:ok, assign(socket, page: page, body: body, html: html, saved: false)}
+  def handle_params(params, _uri, socket) do
+    page = params["page"] || "welcome"
+    existing_body = Content.get_page(page)
+    body = existing_body || "# #{page}"
+    {:noreply, load_page(socket, page, body, new: is_nil(existing_body))} # checks if the page exists already
   end
 
   def handle_event("update", %{"markdown" => body}, socket) do
-    html = Parser.render_html(body)
-    {:noreply, assign(socket, body: body, html: html, saved: false)}
+    {:noreply, load_page(socket, socket.assigns.page, body, saved: false, new: socket.assigns.new)} # keep the new state on each update, until a save event
   end
 
   def handle_event("save", _params, socket) do
     Content.save_page(socket.assigns.page, socket.assigns.body)
-    {:noreply, assign(socket, saved: true)}
+
+    socket =
+      socket
+      |> assign(saved: true, new: false, pages: Content.list_pages()) # saves and set new to false
+      |> put_flash(:info, "\"#{socket.assigns.page}\" saved.")
+
+    {:noreply, socket}
+  end
+
+  def handle_event("new_page", %{"name" => name}, socket) do
+    case String.trim(name) |> String.replace(" ", "-") do
+      "" ->
+        {:noreply, socket}
+      # checks if a page already exists before new page creation
+      slug ->
+        if slug in socket.assigns.pages do
+          {:noreply, put_flash(socket, :error, "\"#{slug}\" already exists.")}
+        else
+          socket =
+            socket
+            |> put_flash(:info, "\"#{slug}\" created.")
+            |> push_navigate(to: ~p"/editor/#{slug}")
+
+          {:noreply, socket}
+        end
+    end
+  end
+
+  defp load_page(socket, page, body, opts) do
+    assign(socket,
+      page: page,
+      body: body,
+      html: Parser.render_html(body),
+      metadata: Parser.metadata(body),
+      saved: Keyword.get(opts, :saved, false),
+      new: Keyword.get(opts, :new, false)
+    )
   end
 end

--- a/lib/manto_web/live/editor_live.html.heex
+++ b/lib/manto_web/live/editor_live.html.heex
@@ -1,33 +1,78 @@
-<main class="flex h-[calc(100vh-68px)] bg-gray-50 dark:bg-gray-900">
-  <!-- Editor -->
-  <section class="w-1/2 p-6 border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 flex flex-col">
-    <h2 class="text-lg font-semibold mb-4">Editing: <%= @page %>.md</h2>
+<Layouts.flash_group flash={@flash} />
 
-    <.form for={%{}} as={:editor} phx-change="update" phx-submit="save" class="flex flex-col flex-1">
-      <textarea name="markdown"
-                class="flex-1 w-full p-4 font-mono text-sm border rounded-md
+<main class="flex h-[calc(100vh-68px)] bg-gray-50 dark:bg-gray-900">
+  <nav class="w-48 shrink-0 p-4 border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-y-auto">
+    <h2 class="text-sm font-semibold uppercase text-gray-500 mb-2">Pages</h2>
+    <ul>
+      <li :for={p <- @pages}>
+        <.link
+          navigate={~p"/editor/#{p}"}
+          class={[
+            "block px-2 py-1 rounded text-sm",
+            if(p == @page,
+              do: "bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-200",
+              else: "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+            )
+          ]}
+        >
+          {p}
+        </.link>
+      </li>
+    </ul>
+
+    <form phx-submit="new_page" class="mt-4 flex gap-1">
+      <input
+        type="text"
+        name="name"
+        placeholder="New page..."
+        class="min-w-0 flex-1 px-2 py-1 text-sm border rounded-md bg-gray-50 dark:bg-gray-900 dark:border-gray-700"
+      />
+      <button
+        type="submit"
+        class="px-2 py-1 text-sm bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
+      >
+        New
+      </button>
+    </form>
+  </nav>
+  
+  <section class="flex-1 p-6 border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 flex flex-col">
+    <h2 class="text-lg font-semibold mb-4">
+      Editing: {Map.get(@metadata, "title", @page)}
+      <span class="text-gray-400 text-sm">({@page}.md)</span>
+    </h2>
+
+    <.form
+      for={%{}}
+      as={:editor}
+      phx-change="update"
+      phx-submit="save"
+      class="flex flex-col flex-1"
+    >
+      <textarea
+        name="markdown"
+        class="flex-1 w-full p-4 font-mono text-sm border rounded-md
                        bg-gray-50 dark:bg-gray-900
                        text-gray-900 dark:text-gray-100
                        focus:ring-2 focus:ring-indigo-500 focus:outline-none"
-                rows="20"><%= @body %></textarea>
+        rows="20"
+      ><%= @body %></textarea>
 
       <div class="mt-4 flex items-center">
-        <button type="submit"
-                class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">
+        <button
+          type="submit"
+          class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
+        >
           Save
         </button>
-        <%= if @saved do %>
-          <span class="ml-3 text-green-600 dark:text-green-400">Saved!</span>
-        <% end %>
       </div>
     </.form>
   </section>
-
-  <!-- Preview -->
-  <section class="w-1/2 p-6 overflow-y-auto bg-gray-50 dark:bg-gray-900">
+  
+  <section class="flex-1 p-6 overflow-y-auto bg-gray-50 dark:bg-gray-900">
     <h2 class="text-lg font-semibold mb-4">Preview</h2>
     <article class="prose dark:prose-invert max-w-none">
-      <%= Phoenix.HTML.raw(@html) %>
+      {Phoenix.HTML.raw(@html)}
     </article>
   </section>
 </main>

--- a/lib/manto_web/router.ex
+++ b/lib/manto_web/router.ex
@@ -19,6 +19,7 @@ defmodule MantoWeb.Router do
 
     get "/", PageController, :home
     live "/editor", EditorLive
+    live "/editor/:page", EditorLive # new route, :page = path parameter
   end
 
   # Other scopes may use custom stacks.

--- a/lib/mix/tasks/manto.build.ex
+++ b/lib/mix/tasks/manto.build.ex
@@ -1,0 +1,81 @@
+defmodule Mix.Tasks.Manto.Build do
+  use Mix.Task
+  alias Manto.Content
+  alias Manto.Content.Parser
+
+  @shortdoc "Builds all pages into a static HTML site"
+
+  @moduledoc """
+  Renders every page under priv/content into standalone static HTML.
+
+      mix manto.build
+      mix manto.build --output dist --theme dark
+
+  Options:
+
+    * `--output`, `-o` - output directory (default: `priv/static_site`)
+    * `--theme`, `-t` - theme name from `priv/themes/*.css` (default: `default`)
+  """
+
+  @impl true
+  def run(args) do
+    Mix.Task.run("app.start") # start app before running the task, depends on Manto.Content module
+
+    {opts, _} = # parses arguments from command
+      OptionParser.parse!(args,
+        strict: [output: :string, theme: :string],
+        aliases: [o: :output, t: :theme]
+      )
+
+    output_dir = Keyword.get(opts, :output, "priv/static_site")
+    theme = Keyword.get(opts, :theme, "default")
+    theme_path = Path.join([:code.priv_dir(:manto), "themes", "#{theme}.css"])
+
+    unless File.exists?(theme_path) do # validates if theme exists
+      Mix.raise("Unknown theme #{inspect(theme)} (looked for #{theme_path})")
+    end
+
+    File.mkdir_p!(output_dir) # output creation and theme copy into it
+    File.cp!(theme_path, Path.join(output_dir, "style.css"))
+
+    pages = Content.list_pages() # get all pages
+
+    for name <- pages do # get content and creates html file
+      body = Content.get_page(name)
+      metadata = Parser.metadata(body)
+      html = Parser.render_html(body, link_prefix: "", link_suffix: ".html")
+      title = Map.get(metadata, "title", name)
+
+      File.write!(
+        Path.join(output_dir, "#{name}.html"),
+        page_template(title: title, body: html, pages: pages, current: name)
+      )
+    end
+
+    Mix.shell().info("Built #{length(pages)} page(s) into #{output_dir}/") # prints success message
+  end
+
+  defp page_template(assigns) do # template for each page
+    nav =
+      Enum.map_join(assigns[:pages], "\n", fn name ->
+        ~s(<a href="#{name}.html">#{name}</a>)
+      end)
+
+    """
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <title>#{assigns[:title]}</title>
+      <link rel="stylesheet" href="style.css" />
+    </head>
+    <body>
+      <nav>#{nav}</nav>
+      <article>
+    #{assigns[:body]}
+      </article>
+    </body>
+    </html>
+    """
+  end
+end

--- a/lib/mix/tasks/manto.init.ex
+++ b/lib/mix/tasks/manto.init.ex
@@ -16,10 +16,18 @@ defmodule Mix.Tasks.Manto.Init do
     File.mkdir_p!(content_dir)
 
     welcome_path = Path.join(content_dir, "welcome.md")
+
     unless File.exists?(welcome_path) do
       Mix.shell().info("Seeding welcome.md...")
+
       File.write!(welcome_path, """
-      # Welcome to Manto!
+      ---
+      title: Welcome to Manto!
+      author: uminocelo
+      created: #{DateTime.utc_now() |> DateTime.to_iso8601()}
+      ---
+
+      # This is Manto!
 
       This is your first local page.
       Edit me in `priv/content/welcome.md` or through the web editor!

--- a/priv/content/welcome.md
+++ b/priv/content/welcome.md
@@ -1,9 +1,0 @@
-# Welcome to Manto!
-
-This is your first local page.
-Edit me in `priv/content/welcome.md` or through the web editor!
-
-
-a
-
-

--- a/priv/themes/dark.css
+++ b/priv/themes/dark.css
@@ -1,0 +1,33 @@
+body {
+  max-width: 42rem;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #e5e7eb;
+  background: #111827;
+  line-height: 1.6;
+}
+
+nav {
+  margin-bottom: 2rem;
+  font-size: 0.875rem;
+}
+
+nav a {
+  margin-right: 1rem;
+}
+
+a {
+  color: #818cf8;
+}
+
+pre {
+  background: #1f2937;
+  padding: 1rem;
+  overflow-x: auto;
+  border-radius: 0.375rem;
+}
+
+code {
+  font-family: ui-monospace, monospace;
+}

--- a/priv/themes/default.css
+++ b/priv/themes/default.css
@@ -1,0 +1,33 @@
+body {
+  max-width: 42rem;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #1f2937;
+  background: #ffffff;
+  line-height: 1.6;
+}
+
+nav {
+  margin-bottom: 2rem;
+  font-size: 0.875rem;
+}
+
+nav a {
+  margin-right: 1rem;
+}
+
+a {
+  color: #4f46e5;
+}
+
+pre {
+  background: #f3f4f6;
+  padding: 1rem;
+  overflow-x: auto;
+  border-radius: 0.375rem;
+}
+
+code {
+  font-family: ui-monospace, monospace;
+}

--- a/test/manto/content/parser_test.exs
+++ b/test/manto/content/parser_test.exs
@@ -1,0 +1,35 @@
+defmodule Manto.Content.ParserTest do
+  use ExUnit.Case, async: true
+  alias Manto.Content.Parser
+
+  test "metadata/1 reads front matter into a map" do
+    md = "---\ntitle: Hello\ntags: a, b\n---\n\n# Body"
+    assert Parser.metadata(md) == %{"title" => "Hello", "tags" => "a, b"}
+  end
+
+  test "metadata/1 returns an empty map without front matter" do
+    assert Parser.metadata("# Just a heading") == %{}
+  end
+
+  test "render_html/1 strips front matter and rewrites wiki links" do
+    md = "---\ntitle: Hello\n---\n\nSee [[Other Page]]."
+    html = Parser.render_html(md)
+
+    refute html =~ "title: Hello"
+    assert html =~ ~s(<a href="/editor/Other-Page">Other Page</a>)
+  end
+
+  test "render_html/2 accepts a custom link prefix/suffix for wiki links" do
+    html = Parser.render_html("See [[Other Page]].", link_prefix: "", link_suffix: ".html")
+    assert html =~ ~s(<a href="Other-Page.html">Other Page</a>)
+  end
+
+  test "render_html/1 renders GFM tables" do
+    md = "| Month | Savings |\n| --- | --- |\n| January | $250 |\n"
+    html = Parser.render_html(md)
+
+    assert html =~ "<table>"
+    assert html =~ "<th>Month</th>"
+    assert html =~ "<td>$250</td>"
+  end
+end

--- a/test/manto_web/live/editor_live_test.exs
+++ b/test/manto_web/live/editor_live_test.exs
@@ -1,0 +1,53 @@
+defmodule MantoWeb.EditorLiveTest do
+  use MantoWeb.ConnCase
+  import Phoenix.LiveViewTest
+
+  test "new page button navigates to a fresh page", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/editor")
+
+    {:error, {:live_redirect, %{to: to}}} =
+      view
+      |> form("form[phx-submit=new_page]", %{name: "My Draft"})
+      |> render_submit()
+
+    assert to == "/editor/My-Draft"
+
+    {:ok, view2, html} = live(conn, to)
+    assert html =~ "My-Draft"
+    assert html =~ "created"
+    assert render(view2) =~ "# My-Draft"
+  end
+
+  test "flags an unsaved page as new and clears the flag once saved", %{conn: conn} do
+    page = "Brand-New-Page-#{System.unique_integer([:positive])}"
+    path = Path.join([:code.priv_dir(:manto), "content", "#{page}.md"])
+    on_exit(fn -> File.rm(path) end)
+
+    {:ok, view, html} = live(conn, "/editor/#{page}")
+    assert html =~ "Draft created!"
+
+    html =
+      view
+      |> form("form[phx-submit=save]", %{markdown: "# #{page}"})
+      |> render_submit()
+
+    refute html =~ "Draft created!"
+  end
+
+  test "does not flag an existing page as new", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/editor/welcome")
+    refute html =~ "Draft created!"
+  end
+
+  test "warns via flash instead of navigating when the page name already exists", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/editor")
+
+    html =
+      view
+      |> form("form[phx-submit=new_page]", %{name: "welcome"})
+      |> render_submit()
+
+    # a plain string (not a live_redirect tuple) proves no navigation happened
+    assert html =~ "already exists"
+  end
+end

--- a/test/mix/tasks/manto.build_test.exs
+++ b/test/mix/tasks/manto.build_test.exs
@@ -1,0 +1,24 @@
+defmodule Mix.Tasks.Manto.BuildTest do
+  use ExUnit.Case, async: false
+
+  test "builds each page into a themed static HTML file" do
+    output_dir =
+      Path.join(System.tmp_dir!(), "manto_build_test_#{System.unique_integer([:positive])}")
+
+    Mix.Task.rerun("manto.build", ["--output", output_dir])
+
+    assert File.exists?(Path.join(output_dir, "style.css"))
+    assert File.exists?(Path.join(output_dir, "welcome.html"))
+
+    html = File.read!(Path.join(output_dir, "welcome.html"))
+    assert html =~ ~s(<link rel="stylesheet" href="style.css" />)
+
+    File.rm_rf!(output_dir)
+  end
+
+  test "raises for an unknown theme" do
+    assert_raise Mix.Error, ~r/Unknown theme/, fn ->
+      Mix.Task.rerun("manto.build", ["--theme", "does-not-exist"])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR introduces several major features to the editor: multi-page navigation, structured front matter metadata, a static site generation mode, and theming support. It also includes a refactor of the content parser and the editor LiveView to improve maintainability and user feedback.

## Changes

### Content Parser
- Refactored Manto.Content.Parser to extract front matter metadata as a fully formatted map, rather than partial/raw data.
- Added table support to Markdown rendering.
- Added support for wiki-style links ([[Page Name]]), rewritten to standard links depending on context (editor vs. static build).

### Editor (LiveView)
- Added /editor/:page route to support navigation via wiki-links.
- Refactored EditorLive:
  - Replaced legacy flag-based conditionals with put_flash/3 to surface success, info, and error messages via toast notifications.
  - Added a new_page event, with validation to prevent overwriting existing pages.
  - Added a navigation sidebar with a form for creating new pages.

### Static Site Generation
- Added mix manto.build task to render all pages into a standalone static HTML site.
- Supports configurable output directory (--output/-o) and theme selection (--theme/-t).
- Reuses the same Parser module used by the live editor, with link rewriting adapted for static file output (relative .html links instead of editor routes).

### Styling
- Added TailwindCSS Typography plugin to app.css to properly style rendered Markdown in the preview pane.
- Added two CSS themes: default and dark, consumed by both the editor and the static build.

### Tests
- Added test coverage (AI-assisted) for the new and refactored functionality.